### PR TITLE
cvmfs 2.1 really is supported now.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,8 +42,8 @@ class cvmfs::config (
 ) inherits cvmfs::params{
 
     case $::cvmfsversion {
-       /^2\.0\.*/: { }
-       default: { info("This cvmfs module is only checked with cvmfs version 2.0.X currently.") }
+       /^2\.[01]\.*/: { }
+       deafault: { info("This cvmfs module is only checked with cvmfs version 2.0.X and 2.1.X currently.") }
     }
 
 


### PR DESCRIPTION
Cvmfs 2.1 support was added a while ago, the check for strictly 2.0 can now be dropped.
