### PR TITLE
fixed cvmfs_public_key name in template

### DIFF
--- a/templates/repo.local.erb
+++ b/templates/repo.local.erb
@@ -29,7 +29,7 @@ CVMFS_TIMEOUT_DIRECT='<%= @cvmfs_timeout_direct %>'
 <% if @cvmfs_nfiles and  @cvmfs_nfiles != '' -%>
 CVMFS_NFILES='<%= @cvmfs_nfiles %>'
 <% end -%>
-<% if @cvmfs_public_keys and @cvmfs_public_key != '' -%>
+<% if @cvmfs_public_key and @cvmfs_public_key != '' -%>
 CVMFS_PUBLIC_KEY='<%= @cvmfs_public_key %>'
 <% end -%>
 <% @cvmfs_force_signing and  if @cvmfs_force_signing != '' -%>
@@ -48,7 +48,7 @@ CVMFS_DEBUGLOG='<%= @cvmfs_debuglog %>'
 CVMFS_MAX_TTL='<%= @cvmfs_max_ttl %>'
 <% end -%>
 <%if @cvmfs_env_variables -%>
-<% @cvmfs_env_variables.each_pair do |var, value| -%> 
-export <%=var-%>=<%=value%> 
-<%end-%> 
-<%end-%> 
+<% @cvmfs_env_variables.each_pair do |var, value| -%>
+export <%=var-%>=<%=value%>
+<%end-%>
+<%end-%>


### PR DESCRIPTION
The variable name cvmfs_public_keys in the test doesn't exist, preventing configuration of public keys.
