### PR TITLE
Remove concat setup dependency

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,8 +108,6 @@ class cvmfs (
   $cvmfs_yum_testsing_enabled = $cvmfs::params::cvmfs_yum_testing_enabled,
 ) inherits cvmfs::params {
 
-  Class['concat::setup'] -> Class['cvmfs']
-
   class{'cvmfs::install':}
 
   # We only even attempt to configure cvmfs if the following


### PR DESCRIPTION
Hi Steve,

As we talked about, I've removed the line referring to Concat::Setup from init.pp. I've tested the module without that line and the configuration ran as expected.

Cheers,
-Frank