### PR TITLE
default.local shouldn't have CVMFS_SERVER_URL, those are domain specific

### DIFF
--- a/templates/repo.local.erb
+++ b/templates/repo.local.erb
@@ -17,8 +17,10 @@ CVMFS_HTTP_PROXY='<%= @cvmfs_http_proxy %>'
 <% if @cvmfs_cache_base and  @cvmfs_cache_base != '' -%>
 CVMFS_CACHE_BASE='<%= @cvmfs_cache_base %>'
 <% end -%>
+<%if @repo -%>
 <% if @cvmfs_server_url and @cvmfs_server_url != '' -%>
 CVMFS_SERVER_URL='<%= @cvmfs_server_url %>'
+<% end -%>
 <% end -%>
 <% if @cvmfs_timeout and  @cvmfs_timeout != '' -%>
 CVMFS_TIMEOUT='<%= @cvmfs_timeout %>'


### PR DESCRIPTION
This patch simply omits the pointless CVMFS_SERVER_URL from default.local