### PR TITLE
Fixes #28 - Readme examples should now all work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,28 @@ of cvmfs is skipped until cvmfs has been installed on the first puppet run.
 Two puppet runs are required to install and then configure cvmfs.
 
 ## Client Configuration
-To configure a cvmfs client enable the module
+To configure a cvmfs client to mount cvmfs repository or a domain
+a domain of cvmfs repositories use the following.
 
 ```puppet
-class{cvmfs:
+class{"cvmfs":
+  cvmfs_http_proxy  => 'http://ca-proxy.example.org:3128',
+  cvmfs_quota_limit => 100
+}
+cvmfs::mount{'files.example.org:
+  cvmfs_server_url  => 'http://web.example.org/cvmfs/files.example.org',
 }
 ```
 or 
 
 ```puppet
-class{'cvmfs':
-  cvmfs_quota      => 100
-  cvmfs_server_url => 'http://web.example.org/cvmfs/cmfs.example.org'
+class{"cvmfs":
+  cvmfs_http_proxy  => 'http://ca-proxy.example.org:3128',
+  cvmfs_quota_limit => 100,
+}
+
+cvmfs::domain{'example.net'
+  cvmfs_server_url   => 'http://web.example.org/cvmfs/@fqrn@'
 }
 ```
 
@@ -64,14 +74,13 @@ class{'cvmfs':
    in the default.local file.
 
 
-The global defaults for all repositories are maintained within
-params.pp.  These global values end up in /etc/cvmfs/cvmfs.local.
-
-puppet data bindings can be used to specify these values within hiera
+Puppet databindings allows all the above settings to be set via hiera. In
+this case it is not nescesary to include `class{'cvmfs':}`.
 
 ```YAML
 ---
-cvmfs::cvmfs_quota: 100
+cvmfs::cvmfs_quota_limit: 100
+cvmfs::cvmfs_nfiles: 20000
 ```
 
 
@@ -82,10 +91,11 @@ configuration on each repository. e.g
 ```puppet
 cvmfs::mount{'lhcb.example.org':
 }
-cvmfs::mount{'atlas.example.org': cvmfs_quota    => 50 
+cvmfs::mount{'atlas.example.org': 
+  cvmfs_timeout => 50 
 }
 cvmfs::mount{'cms.example.org': 
-  cvmfs_quota      => 100,
+  cvmfs_timeout    => 100,
   cvmfs_server_url => 'http://web.example.org/cms.cern.ch' 
 }
 ```                                 
@@ -99,8 +109,8 @@ cvmfs::mount{'cms.example.org':
 
 
 In addition to creating mounts as above the
-`create_resources('cvmfs::mount',{})` function is called with
-in init allow the mounts to be specified in a hiera yaml file:
+`create_resources('cvmfs::mount',{})` function is called
+allowing the mounts to be specified in a hiera yaml file:
 
 ```YAML
 ---

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -11,6 +11,7 @@ define cvmfs::domain($cvmfs_quota_limit = undef,
   $cvmfs_use_geoapi = undef
 ) {
 
+  include cvmfs
   # We only even attempt to configure cvmfs if the following
   # two facts are available and that requires that cvmfs
   # has been installed first potentially on the first puppet

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,8 +22,13 @@ class cvmfs (
   $cvmfs_yum_proxy            = $cvmfs::params::cvmfs_proxy,
   $cvmfs_yum_testing          = $cvmfs::params::cvmfs_yum_testing,
   $cvmfs_yum_testsing_enabled = $cvmfs::params::cvmfs_yum_testing_enabled,
-  $cvmfs_use_geoapi           = $cvmfs::params::cvmfs_geoapi
+  $cvmfs_use_geoapi           = $cvmfs::params::cvmfs_geoapi,
+  $cvmfs_server_url           = $cvmfs::params::cvmfs_server_url
 ) inherits cvmfs::params {
+
+  if $cvmfs_server_url != ''  {
+    warning('The $cvmfs_server_url to cvmfs is deprecated, please set this value per mount or per domain.')
+  }
 
   class{'cvmfs::install':}
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -12,6 +12,7 @@ define cvmfs::mount($cvmfs_quota_limit = undef,
   $cvmfs_repo_list = true
 ) {
 
+  include cvmfs
   # We only even attempt to configure cvmfs if the following
   # two facts are available and that requires that cvmfs
   # has been installed first potentially on the first puppet

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class cvmfs::params {
   $cvmfs_quota_ratio  = hiera('cvmfs_quota_ratio','0.85')
 
   $cvmfs_http_proxy       = hiera('cvmfs_http_proxy','http://squid.example.org:3128')
-  $cvmfs_server_url       = hiera('cvmfs_server_url','http://web.example.org:80/opt/example')
+  $cvmfs_server_url       = hiera('cvmfs_server_url','')
   case $::cvmfsversion {
     /^2\.0\.*/: {
       $default_cvmfs_cache_base  = '/var/cache/cvmfs2'

--- a/spec/acceptance/cvmfs_mount_cern_domain_spec.rb
+++ b/spec/acceptance/cvmfs_mount_cern_domain_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper_acceptance'
 
-describe 'cvmfs::mount atlas.cern.ch' do
+describe 'cvmfs::domain cern.ch' do
     it 'should configure and work with no errors' do
       pp = <<-EOS
          class{"cvmfs":
              cvmfs_http_proxy => 'http://ca-proxy.cern.ch:3128;DIRECT',
          }
-         cvmfs::mount{'atlas.cern.ch':
-            cvmfs_server_url =>  'http://cvmfs-stratum-one.cern.ch/cvmfs/atlas.cern.ch'
+         cvmfs::domain{'cern.ch':
+            cvmfs_server_url =>  'http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@'
          }
       EOS
       # Run it three times, it should be stable by then
@@ -16,6 +16,6 @@ describe 'cvmfs::mount atlas.cern.ch' do
       apply_manifest(pp, :catch_changes => true)
       # The automounter can retrun before it is actually working.
       shell('sleep 10')
-      shell('ls /cvmfs/atlas.cern.ch/repo',  :acceptable_exit_codes => 0)
+      shell('ls /cvmfs/cms.cern.ch',  :acceptable_exit_codes => 0)
     end
 end

--- a/spec/classes/cvmfs_spec.rb
+++ b/spec/classes/cvmfs_spec.rb
@@ -40,9 +40,10 @@ describe 'cvmfs' do
         let(:params) {{:config_automaster  => false}}
         it { should_not contain_augeas('cvmfs_automaster') }
       end
-
+      context 'with cvmfs_server_url set to something, to be deprecated' do
+        let(:params) {{:cvmfs_server_url => 'http://example.org/cvmfs/files.repo.org'}}
+        it { should compile.with_all_deps }
+      end
     end
-
   end
-
 end

--- a/spec/defines/domain_spec.rb
+++ b/spec/defines/domain_spec.rb
@@ -4,22 +4,20 @@ describe 'cvmfs::domain' do
 
   let(:title) {'example.org'}
   
-  context 'with defaults' do
-    it { should compile.with_all_deps }
-
-    it { should_not contain_file('/etc/cvmfs/domain.d/example.org.local')}
-    context 'with cvmfsversion and cvmfspartsize facts set' do
-      let(:facts) {{:osfamily => 'RedHat',
+  context 'with defaults, cvmfsversion and cvmfspartsize set' do
+    let(:facts) {{:osfamily => 'RedHat',
                    :uptime_days => 1,
                     :operatingsystemrelease => '7.1.1503',
                     :kernelrelease => '3.10.0-229.1.2.el7.x86_64',
                     :cvmfsversion => '2.1.20', :cvmfspartsize => '20000'}}
-      it { should contain_file('/etc/cvmfs/domain.d/example.org.local') }
-      context 'with cvmfs_use_geoapi set' do
-        let(:params) {{:cvmfs_use_geoapi => 'yes' }}
-        it { should contain_file('/etc/cvmfs/domain.d/example.org.local').with({
-          'content' => /^CVMFS_USE_GEOAPI='yes'$/})}
-        end
+
+    it { should compile.with_all_deps }
+    it { should contain_file('/etc/cvmfs/domain.d/example.org.local') }
+
+    context 'with cvmfs_use_geoapi set' do
+      let(:params) {{:cvmfs_use_geoapi => 'yes' }}
+      it { should contain_file('/etc/cvmfs/domain.d/example.org.local').with({
+       'content' => /^CVMFS_USE_GEOAPI='yes'$/})}
     end
   end
 end

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -4,23 +4,20 @@ describe 'cvmfs::mount' do
 
   let(:title) {'files.example.org'}
   
-  context 'with defaults' do
+  context 'with defaults, cvmfspartsize, cvmfsversion facts set' do
+    let(:facts) {{:osfamily => 'RedHat',
+                  :uptime_days => 1,
+                  :operatingsystemrelease => '7.1.1503',
+                  :kernelrelease => '3.10.0-229.1.2.el7.x86_64',
+                  :cvmfsversion => '2.1.20', :cvmfspartsize => '20000'}}
     it { should compile.with_all_deps }
 
-    it { should_not contain_file('/etc/cvmfs/config.d/files.example.org.local')}
-    context 'with cvmfsversion and cvmfspartsize facts set' do
-      let(:facts) {{:osfamily => 'RedHat',
-                   :uptime_days => 1,
-                    :operatingsystemrelease => '7.1.1503',
-                    :kernelrelease => '3.10.0-229.1.2.el7.x86_64',
-                    :cvmfsversion => '2.1.20', :cvmfspartsize => '20000'}}
-      it { should contain_file('/etc/cvmfs/config.d/files.example.org.local') }
+    it { should contain_file('/etc/cvmfs/config.d/files.example.org.local') }
       context 'with cvmfs_use_geoapi set' do
         let(:params) {{:cvmfs_use_geoapi => 'yes' }}
         it { should contain_file('/etc/cvmfs/config.d/files.example.org.local').with({
           'content' => /^CVMFS_USE_GEOAPI='yes'$/})}
         end
     end
-  end
 end
 


### PR DESCRIPTION
Setting $cvmfs_server_url on cvmfs class now produces a warning.