### PR TITLE
Fixed package names in dependency list.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,19 +9,19 @@
   "dependencies": [
     {
       "version_requirement": ">=1.0.0",
-      "name": "puppetlabs-concat"
+      "name": "puppetlabs/concat"
     },
     {
       "version_requirement": ">=1.0.0",
-      "name": "puppetlabs-stdlib"
+      "name": "puppetlabs/stdlib"
     },
     {
       "version_requirement": ">=1.0.0",
-      "name": "puppetlabs-firewall"
+      "name": "puppetlabs/firewall"
     },
     {
       "version_requirement": ">=0.3.1",
-      "name": "erwbgy-limits"
+      "name": "erwbgy/limits"
     }
   ],
 


### PR DESCRIPTION
Package names in dependency list use slashes instead of dashes.
Dashes lead to warnings.