### PR TITLE
cvmf::install: allow to disable yum repository management

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ cvmfs::domain{'example.net'
 * `cvmfs_yum_testsing_enabled` **TO DOC**
 * `cvmfs_yum_gpgcheck`  Defaults to true, set to false to disable GPG checking (Do Not Do This)
 * `cvmfs_yum_gpgkey`  Set a custom GPG key for yum repos, you must deploy it yourself.
+* `cvmfs_yum_manage_repo` Defaults to true, set to false to disable yum repositories management.
 * `cvmfs_use_geoapi`  **TO DOC**
 
 * `cvmfs_hash` Rather than using cvmfs::mount defined type a hash of mounts can be sepecfied.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,7 @@ class cvmfs (
   $cvmfs_use_geoapi           = $cvmfs::params::cvmfs_use_geoapi,
   $cvmfs_server_url           = $cvmfs::params::cvmfs_server_url,
   $cvmfs_follow_redirects     = $cvmfs::params::cvmfs_follow_redirects,
+  $cvmfs_yum_manage_repo      = $cvmfs::params::cvmfs_yum_manage_repo,
 ) inherits cvmfs::params {
 
   if $cvmfs_server_url != ''  {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,10 +20,13 @@
 class cvmfs::install (
   $cvmfs_version = $cvmfs::cvmfs_version,
   $cvmfs_cache_base = $cvmfs::cvmfs_cache_base,
+  $cvmfs_yum_manage_repo = $cvmfs::cvmfs_yum_manage_repo,
 
 ) inherits cvmfs {
 
-  class{'::cvmfs::yum':}
+  if $cvmfs_yum_manage_repo {
+    class{'::cvmfs::yum':}
+  }
 
   # Create the cache dir if one is defined, otherwise assume default is in the package.
   # Require the package so we know the user is in place.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,7 +71,7 @@ class cvmfs::params {
 
   $cvmfs_yum_proxy        = hiera('cvmfs_yum_proxy','_none_')
 
-  $cvmfs_yum_manage_repo  = hiera('cvmfs_yum_manage_repo',true)
+  $cvmfs_yum_manage_repo  = true
 
   # Only used is cvmfs::server is enabled.
   $cvmfs_kernel_version     = hiera('cvmfs_kernel_version','present')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,6 +71,8 @@ class cvmfs::params {
 
   $cvmfs_yum_proxy        = hiera('cvmfs_yum_proxy','_none_')
 
+  $cvmfs_yum_manage_repo  = hiera('cvmfs_yum_manage_repo',true)
+
   # Only used is cvmfs::server is enabled.
   $cvmfs_kernel_version     = hiera('cvmfs_kernel_version','present')
   $cvmfs_yum_kernel         = hiera('cvmfs_yum_kernel',"http://cern.ch/cvmrepo/yum/cvmfs-kernel/EL/${::operatingsystemmajrelease}/${::architecture}")

--- a/spec/classes/cvmfs_spec.rb
+++ b/spec/classes/cvmfs_spec.rb
@@ -74,6 +74,22 @@ describe 'cvmfs' do
         it { should contain_yumrepo('cvmfs-config').with_gpgkey('http://example.org/key.gpg') }
       end
 
+      context 'with cvmfs_yum_manage_repo set to true' do
+        let(:params) {{:cvmfs_yum_manage_repo => true}}
+        it { should contain_class('cvmfs::yum') }
+        it { should contain_yumrepo('cvmfs') }
+        it { should contain_yumrepo('cvmfs-testing') }
+        it { should contain_yumrepo('cvmfs-config') }
+      end
+
+      context 'with cvmfs_yum_manage_repo set to false' do
+        let(:params) {{:cvmfs_yum_manage_repo => false}}
+        it { should_not contain_class('cvmfs::yum') }
+        it { should_not contain_yumrepo('cvmfs') }
+        it { should_not contain_yumrepo('cvmfs-testing') }
+        it { should_not contain_yumrepo('cvmfs-config') }
+      end
+
       context 'with manage_autofs_service true' do
         let(:params) {{:manage_autofs_service => true}}
         it { should contain_service('autofs') }


### PR DESCRIPTION
PR allowing to disable yum repository managememt using the boolen cvmfs::cvmfs_yum_manage_repo class attribute.
Users might want to manage yum repositories using some special modules (like example42/yum) and in order to do this the yumrepo/gpg keys calls should be optional.
This PR is reverse compatible as repo management is enabled by default.