### PR TITLE
use ensure_packages to avoid "redef errors"

### DIFF
--- a/manifests/one/install.pp
+++ b/manifests/one/install.pp
@@ -9,7 +9,7 @@ class cvmfs::one::install (
     ensure  => $cvmfs_version,
     require => Yumrepo['cvmfs'],
   }
-  package{['httpd','mod_wsgi']:
-    ensure => present,
-  }
+
+  # Don't conflict if already declared
+  ensure_packages(['httpd','mod_wsgi'], { ensure => present,})
 }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -18,9 +18,7 @@ class cvmfs::server::install (
   package{'aufs2-util':
     ensure => $cvmfs_aufs2_version,
   }
-  package{'httpd':
-    ensure => present,
-  }
+  ensure_packages('httpd', { ensure => present, })
 }
 
 

--- a/manifests/zero/install.pp
+++ b/manifests/zero/install.pp
@@ -26,7 +26,5 @@ class cvmfs::zero::install (
     ensure  => $cvmfs_aufs2_version,
     require => Yumrepo['cvmfs-kernel'],
   }
-  package{'httpd':
-    ensure => present,
-  }
+  ensure_packages('httpd', { ensure => present, } )
 }


### PR DESCRIPTION
ensure_packages from stdlib cleans up a minor annoyance on my end.