### PR TITLE
one: sync in parallel at 15 minute intervals

### DIFF
--- a/files/sync-cron.sh
+++ b/files/sync-cron.sh
@@ -4,8 +4,9 @@ for r in $(cd /srv/cvmfs ; echo *.*)
 do 
  (echo ""
   echo "Starting $r at $(date)"
-  cvmfs_server snapshot $r || echo  "ERROR from cvmfs_server"
+  cvmfs_server snapshot -t $r || echo  "ERROR from cvmfs_server"
   echo "Finished $r at $(date)"
-  ) >> /var/log/cvmfs/$r.log 2>&1 
+  ) >> /var/log/cvmfs/$r.log 2>&1 &
 done
 
+wait

--- a/manifests/one/config.pp
+++ b/manifests/one/config.pp
@@ -24,7 +24,7 @@ class cvmfs::one::config {
 
   cron{'cvmfs_sync':
     user    => cvmfsr,
-    minute  => [0,30],
+    minute  => '*/15',
     command => '/usr/local/sbin/sync-cron.sh',
     require => File['/usr/local/sbin/sync-cron.sh'],
   }


### PR DESCRIPTION
Sync the repos all in parallel and use the -t option to cvmfs_server so that overlapping snapshots don't pile up.