### PR TITLE
Make module work on apt-based OSes

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,7 +25,12 @@ class cvmfs::install (
 ) inherits cvmfs {
 
   if $cvmfs_yum_manage_repo {
-    class{'::cvmfs::yum':}
+    if $::osfamily == 'RedHat' {
+      class{'::cvmfs::yum':}
+    }
+    else {
+      fail('cvmfs_yum_manage_repo can only be set true for the RedHat OS family')
+    }
   }
 
   # Create the cache dir if one is defined, otherwise assume default is in the package.
@@ -49,11 +54,16 @@ class cvmfs::install (
       require => Package['cvmfs'],
     }
   }
+  if $::osfamily == 'RedHat' {
+	$cvmfs_requirements = Yumrepo['cvmfs']
+  }
+  else {
+	$cvmfs_requirements = []
+  }
   package{'cvmfs':
     ensure  => $cvmfs_version,
-    require => Yumrepo['cvmfs'],
+    require => $cvmfs_requirements,
   }
-
 
   # Create a file for the cvmfs
   file{'/etc/cvmfs/cvmfsfacts.yaml':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,8 +4,8 @@ class cvmfs::params {
   # For now just check os and exit if it untested.
   if $::osfamily == 'RedHat' and $::operatingsystem == 'Fedora' {
     fail('This cvmfs module has not been verified under fedora.')
-  } elsif $::osfamily != 'RedHat' {
-    fail('This cvmfs module has not been verified under osfamily other than RedHat')
+  } elsif $::osfamily != 'RedHat' and $::osfamily != 'Debian' {
+    fail('This cvmfs module has not been verified under your OS.')
   }
 
   # This cvmfs module will also configure autofs as well for use


### PR DESCRIPTION
This patch makes the module work on OSes of the Debian family. Due to a lack of an equivalent resource type to `yumrepo` for apt-based systems, `cvmfs_yum_manage_repo` must be set to false for Debian based OSes. The repository which provides the cvmfs packages thus needs to be configured  externally (e. g. using [this module](https://github.com/puppetlabs/puppetlabs-apt)).
