### PR TITLE
Bug, do not require yumrepo if not included

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
   - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=build
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
-  - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'puppetlabs_spec_helper',                                     :require => false
-  gem 'rspec-puppet',                                               :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'puppetlabs_spec_helper', '~> 1.2.2',                         :require => false
+  gem 'rspec-puppet', '~> 2.5',                                     :require => false
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
   gem 'puppet-lint-absolute_classname-check',                       :require => false
@@ -25,9 +25,12 @@ group :test do
   gem 'metadata-json-lint',                                         :require => false
   gem 'puppet-blacksmith',                                          :require => false
   gem 'voxpupuli-release',                                          :require => false, :git => 'https://github.com/voxpupuli/voxpupuli-release-gem.git'
-  gem 'puppet-strings',                                             :require => false, :git => 'https://github.com/puppetlabs/puppetlabs-strings.git'
-  gem 'rubocop-rspec', '~> 1.5',                                    :require => false if RUBY_VERSION >= '2.3.0'
+  gem 'puppet-strings', '~> 0.99.0',                                :require => false
+  gem 'rubocop-rspec', '~> 1.6',                                    :require => false if RUBY_VERSION >= '2.3.0'
   gem 'json_pure', '<= 2.0.1',                                      :require => false if RUBY_VERSION < '2.0.0'
+  gem 'mocha', '>= 1.2.1',                                          :require => false
+  gem 'coveralls',                                                  :require => false if RUBY_VERSION >= '2.0.0'
+  gem 'simplecov-console',                                          :require => false if RUBY_VERSION >= '2.0.0'
 end
 
 group :development do
@@ -45,6 +48,7 @@ group :system_tests do
   else
     gem 'beaker-rspec',  :require => false
   end
+  gem 'serverspec',                    :require => false
   gem 'beaker-puppet_install_helper',  :require => false
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,9 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet_blacksmith/rake_tasks'
 require 'voxpupuli/release/rake_tasks'
-require 'puppet-strings/rake_tasks'
+require 'puppet-strings/tasks'
 
-if RUBY_VERSION >= '2.3.0'
-  require 'rubocop/rake_task'
-
-  RuboCop::RakeTask.new(:rubocop) do |task|
-    # These make the rubocop experience maybe slightly less terrible
-    task.options = ['-D', '-S', '-E']
-  end
-end
-
-PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{check}:%{KIND}:%{message}'
+PuppetLint.configuration.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{message}'
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_140chars')
@@ -34,11 +25,9 @@ RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-desc 'Run tests metadata_lint, lint, syntax, spec'
+desc 'Run tests metadata_lint, release_checks'
 task test: [
   :metadata_lint,
-  :lint,
-  :syntax,
-  :spec,
+  :release_checks,
 ]
 # vim: syntax=ruby

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class cvmfs (
     warning('The $cvmfs_server_url to cvmfs is deprecated, please set this value per mount or per domain.')
   }
 
+  validate_bool($cvmfs_yum_manage_repo)
   validate_re($mount_method,['^autofs$','^mount$','^none$'],'$mount_method must be one of autofs (default), mount or none')
 
   anchor{'cvmfs::begin':} ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -49,9 +49,15 @@ class cvmfs::install (
       require => Package['cvmfs'],
     }
   }
+
+  $_pkgrequire = $cvmfs_yum_manage_repo ? {
+    true  => Yumrepo['cvmfs'],
+    false => undef,
+  }
+
   package{'cvmfs':
     ensure  => $cvmfs_version,
-    require => Yumrepo['cvmfs'],
+    require => $_pkgrequire,
   }
 
 

--- a/spec/classes/cvmfs_spec.rb
+++ b/spec/classes/cvmfs_spec.rb
@@ -17,6 +17,7 @@ describe 'cvmfs' do
     it { should contain_class('cvmfs::config') }
     it { should contain_class('cvmfs::service') }
     it { should contain_package('cvmfs').with_ensure('present') }
+    it { should contain_package('cvmfs').with_require('Yumrepo[cvmfs]') }
 
     context 'with defaults and cvmfspartsize fact unset' do
       let(:facts) do
@@ -126,6 +127,8 @@ describe 'cvmfs' do
 
       context 'with cvmfs_yum_manage_repo set to false' do
         let(:params) { { cvmfs_yum_manage_repo: false } }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to  have_yumrepo_resource_count(0) }
         it { should_not contain_class('cvmfs::yum') }
         it { should_not contain_yumrepo('cvmfs') }
         it { should_not contain_yumrepo('cvmfs-testing') }


### PR DESCRIPTION
    If `cvmfs::cvmfs_yum_manage_repo` was
    false and the cvmfs yum repositories were not included
    the package declaration of cvmfs
    stil required the yumrepo to be present which is not
    sensible.
