### PR TITLE
Purge config.d directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@ class cvmfs::config (
   $default_cvmfs_partsize = $cvmfs::default_cvmfs_partsize,
 ) inherits cvmfs {
 
-  # If cvmfspartsize fact exists use it, otherwise use a sensible default. 
+  # If cvmfspartsize fact exists use it, otherwise use a sensible default.
   if getvar(::cvmfspartsize) {
     $_cvmfs_partsize = $::cvmfspartsize
   } else {
@@ -32,10 +32,10 @@ class cvmfs::config (
     default: { $my_cvmfs_quota_limit = $cvmfs_quota_limit }
   }
 
-  # Clobber the /etc/cvmfs/domain.d directory.
+  # Clobber the /etc/cvmfs/(domain|config).d directories.
   # This puppet module just does not support
-  # concept of this directory so it's safer to clean it.
-  file{'/etc/cvmfs/domain.d':
+  # concept of these directories so it's safer to clean them.
+  file{ ['/etc/cvmfs/domain.d', '/etc/cvmfs/config.d']:
     ensure  => directory,
     purge   => true,
     recurse => true,
@@ -52,6 +52,14 @@ class cvmfs::config (
     mode    => '0644',
     content => "This directory is managed by puppet but *.conf files are ignored from purging\n",
     require => File['/etc/cvmfs/domain.d'],
+  }
+  file{'/etc/cvmfs/config.d/README.PUPPET':
+    ensure  => file,
+    owner   => root,
+    group   => root,
+    mode    => '0644',
+    content => "This directory is managed by puppet but *.conf files are ignored from purging\n",
+    require => File['/etc/cvmfs/config.d'],
   }
 
   # Clobber the /etc/fuse.conf, hopefully no


### PR DESCRIPTION
This will remove old configuration files which were created by cvmfs::mount when the mount is removed from puppet.