### PR TITLE
Add yum priorties to cvmfs yum repo

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class cvmfs::params {
   # Permitted to be 'autofs' or 'mount' or 'none currently.
   $mount_method = 'autofs'
 
-  # Now deprecated 
+  # Now deprecated
   $config_automaster      = hiera('cvmfs_config_automaster',true)
 
   # Manage the autofs service itself.
@@ -76,6 +76,7 @@ class cvmfs::params {
   $cvmfs_yum_testing_enabled = hiera('cvmfs_yum_testing_enabled','0')
 
   $cvmfs_yum_proxy        = undef
+  $cvmfs_yum_priorities   = hiera('cvmfs_yum_priorities')
 
   $cvmfs_yum_manage_repo  = true
 

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -20,6 +20,7 @@ class cvmfs::yum (
   $cvmfs_yum_proxy = $cvmfs::cvmfs_yum_proxy,
   $cvmfs_yum_gpgcheck = $cvmfs::cvmfs_yum_gpgcheck,
   $cvmfs_yum_gpgkey = $cvmfs::cvmfs_yum_gpgkey,
+  $cvmfs_yum_priorities = $cvmfs::cvmfs_yum_priorities,
 )  inherits cvmfs {
 
   yumrepo{'cvmfs':
@@ -29,7 +30,7 @@ class cvmfs::yum (
     gpgkey      => $cvmfs_yum_gpgkey,
     enabled     => 1,
     includepkgs => 'cvmfs,cvmfs-keys,cvmfs-server,cvmfs-config-default',
-    priority    => 80,
+    priority    => $cvmfs_yum_priorities,
     require     => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'],
     proxy       => $cvmfs_yum_proxy,
   }
@@ -40,7 +41,7 @@ class cvmfs::yum (
     gpgkey      => $cvmfs_yum_gpgkey,
     enabled     => $cvmfs_yum_testing_enabled,
     includepkgs => 'cvmfs,cvmfs-keys,cvmfs-server,cvmfs-config-default',
-    priority    => 80,
+    priority    => $cvmfs_yum_priorities,
     require     => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'],
     proxy       => $cvmfs_yum_proxy,
   }
@@ -50,7 +51,7 @@ class cvmfs::yum (
     gpgcheck => $cvmfs_yum_gpgcheck,
     gpgkey   => $cvmfs_yum_gpgkey,
     enabled  => $cvmfs_yum_config_enabled,
-    priority => 80,
+    priority => $cvmfs_yum_priorities,
     require  => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'],
     proxy    => $cvmfs_yum_proxy,
   }
@@ -65,4 +66,3 @@ class cvmfs::yum (
     mode    => '0644',
   }
 }
-


### PR DESCRIPTION
Hi Steve!

I have added a parameter $cvmfs_yum_priorites as the value for the priority in the yum repository is right now hardcoded to 80.

UMD-4 has a priority of 10 and older versions of cvmfs.  If one wants to get the newer 
versions, one has to set the priority to lower value, for example 9.

Cheers, Dietrich

