### PR TITLE
cvmfs::fsck: tmpwatch on RedHat, tmpreaper on Debian.

### DIFF
--- a/manifests/fsck.pp
+++ b/manifests/fsck.pp
@@ -14,11 +14,23 @@ class cvmfs::fsck (
   }
   # -i <value> flag to script says cron job will exit early if uptime is less than this value.
 
+  $tmpcleaning_cmd = $::osfamily ? {
+    'RedHat' => '/usr/sbin/tmpwatch -umc -f 30d',
+    'Debian' => '/usr/sbin/tmpreaper -m -f 30d',
+    default  => '/usr/sbin/tmpwatch -umc -f 30d',
+  }
+
+  $tmpcleaning_pkg = $::osfamily ? {
+    'RedHat' => 'tmpwatch',
+    'Debian' => 'tmpreaper',
+    default  => 'tmpwatch',
+  }
+
   cron{'clean_quarentine':
     hour    => fqdn_rand(24,'cvmfs_purge'),
     minute  => fqdn_rand(60,'cvmfs_purge'),
     weekday => fqdn_rand(7,'cvmfs_purge'),
-    command => "/usr/sbin/tmpwatch -umc -f 30d ${cvmfs_cache_base}/shared/quarantaine",
+    command => "${tmpcleaning_cmd} ${cvmfs_cache_base}/shared/quarantaine",
   }
 
   cron{'cvmfs_fsck':
@@ -26,7 +38,7 @@ class cvmfs::fsck (
     minute  => fqdn_rand(60,'cvmfs'),
     weekday => fqdn_rand(7,'cvmfs'),
     command => '/usr/local/sbin/cvmfs_fsck_cron.sh -i 86400  2>&1 | /bin/awk \'{ print strftime("\%Y-\%m-\%d \%H:\%M:\%S"), $0; }\'  >> /var/log/cvmfs_fsck.log',
-    require => [File['/usr/local/sbin/cvmfs_fsck_cron.sh'],Package['tmpwatch']],
+    require => [File['/usr/local/sbin/cvmfs_fsck_cron.sh'],Package[$tmpcleaning_pkg]],
   }
   if $onreboot {
     cron{'cvmfs_fsck_on_reboot':
@@ -42,6 +54,6 @@ class cvmfs::fsck (
     group  => 'root',
     source => 'puppet:///modules/cvmfs/cvmfs_fsck.logrotate',
   }
-  ensure_packages(['tmpwatch'])
+  ensure_packages([$tmpcleaning_pkg])
 }
 


### PR DESCRIPTION
tmpreaper is not available on RedHat,
and vice-versa.