### PR TITLE
fsck: Fix path for awk.

### DIFF
--- a/manifests/fsck.pp
+++ b/manifests/fsck.pp
@@ -37,12 +37,12 @@ class cvmfs::fsck (
     hour    => fqdn_rand(24,'cvmfs'),
     minute  => fqdn_rand(60,'cvmfs'),
     weekday => fqdn_rand(7,'cvmfs'),
-    command => '/usr/local/sbin/cvmfs_fsck_cron.sh -i 86400  2>&1 | /bin/awk \'{ print strftime("\%Y-\%m-\%d \%H:\%M:\%S"), $0; }\'  >> /var/log/cvmfs_fsck.log',
+    command => '/usr/local/sbin/cvmfs_fsck_cron.sh -i 86400  2>&1 | /usr/bin/awk \'{ print strftime("\%Y-\%m-\%d \%H:\%M:\%S"), $0; }\'  >> /var/log/cvmfs_fsck.log',
     require => [File['/usr/local/sbin/cvmfs_fsck_cron.sh'],Package[$tmpcleaning_pkg]],
   }
   if $onreboot {
     cron{'cvmfs_fsck_on_reboot':
-      command => '/usr/local/sbin/cvmfs_fsck_cron.sh -i 0 2>&1 | /bin/awk \'{ print strftime("\%Y-\%m-\%d \%H:\%M:\%S"), $0; }\'  >> /var/log/cvmfs_fsck.log',
+      command => '/usr/local/sbin/cvmfs_fsck_cron.sh -i 0 2>&1 | /usr/bin/awk \'{ print strftime("\%Y-\%m-\%d \%H:\%M:\%S"), $0; }\'  >> /var/log/cvmfs_fsck.log',
       special => 'reboot',
       require => File['/usr/local/sbin/cvmfs_fsck_cron.sh'],
     }

--- a/templates/cvmfs_fsck_cron.sh.erb
+++ b/templates/cvmfs_fsck_cron.sh.erb
@@ -19,6 +19,6 @@ UPTIME=$(/usr/bin/awk -F'[ .]' '{print $1}' /proc/uptime)
 # Only run if up for more than one day. If you want sooner enable the
 # on reboot cron job.
 if [ $UPTIME -gt $IGNORE ] && [ -d <%= @cvmfs_cache_base %>/shared  ] ; then
-   /bin/nice /usr/bin/cvmfs_fsck <%= @options %> <%= @cvmfs_cache_base %>/shared 
+   /usr/bin/nice /usr/bin/cvmfs_fsck <%= @options %> <%= @cvmfs_cache_base %>/shared 
 fi
 


### PR DESCRIPTION
It's /usr/bin/awk, not /bin/awk. The latter works
on accident on RHEL-based distros since /bin is a symlink
to /usr/bin.