### PR TITLE
Fixes #66 drop CVMFS_FORCE_SIGNING

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ cvmfs::mount{'myrepo.example.org':
 * `cvmfs_timeout` cvmfs timeout setting, see params.pp for default.
 * `cvmfs_timeout_direct` cvmfs timeout to direct connections, see params.pp for default.
 * `cvmfs_nfiles` Number of open files, system setting, see params.pp for default.
-* `cvmfs_force_signing` Boolean defaults to true, repositories must be signed.
 * `cvmfs_syslog_level`  Default is in params.pp
 * `cvmfs_tracefile`  Create a tracefile at this location.
 * `cvmfs_debuglog` Create a debug log file at this location.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,6 @@ class cvmfs (
   $cvmfs_timeout              = $cvmfs::params::cvmfs_timeout,
   $cvmfs_timeout_direct       = $cvmfs::params::cvmfs_timeout_direct,
   $cvmfs_nfiles               = $cvmfs::params::cvmfs_nfiles,
-  $cvmfs_force_signing        = $cvmfs::params::cvmfs_force_signing,
   $cvmfs_syslog_level         = $cvmfs::params::cvmfs_syslog_level,
   $cvmfs_tracefile            = $cvmfs::params::cvmfs_tracefile,
   $cvmfs_debuglog             = $cvmfs::params::cvmfs_debuglog,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -103,14 +103,6 @@ class cvmfs::params {
     $cvmfs_public_key = ''
   }
 
-  $_cvmfs_force_signing          = hiera('cvmfs_force_signing',false)
-  if $_cvmfs_force_signing {
-    notify{'Setting cvmfs_force_signing as a hiera variable is deprecated, use cvmfs::cvmfs_force_signing now':}
-    $cvmfs_force_signing = $_cvmfs_force_signing
-  } else {
-    $cvmfs_force_signing = 'yes'
-  }
-
   $_cvmfs_syslog_level          = hiera('cvmfs_syslog_level',false)
   if $_cvmfs_syslog_level {
     notify{'Setting cvmfs_syslog_level as a hiera variable is deprecated, use cvmfs::cvmfs_syslog_level now':}

--- a/templates/repo.local.erb
+++ b/templates/repo.local.erb
@@ -38,9 +38,6 @@ CVMFS_NFILES='<%= @cvmfs_nfiles %>'
 <% if @cvmfs_public_key and @cvmfs_public_key != '' -%>
 CVMFS_PUBLIC_KEY='<%= @cvmfs_public_key %>'
 <% end -%>
-<% @cvmfs_force_signing and  if @cvmfs_force_signing != '' -%>
-CVMFS_FORCE_SIGNING='<%= @cvmfs_force_signing %>'
-<% end -%>
 <% if @cvmfs_syslog_level and  @cvmfs_syslog_level != '' -%>
 CVMFS_SYSLOG_LEVEL='<%= @cvmfs_syslog_level %>'
 <% end -%>


### PR DESCRIPTION
The `CVMFS_FORCE_SIGNING` parameter was only relavent
to a much older version of CvmFS and has not been used
for years.