### PR TITLE
New yum_priority parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ cvmfs::mount{'myrepo.example.org':
 * `cvmfs_max_ttl` Max ttl, see params.pp for default.
 * `cvmfs_version` Version of cvmfs to install , default is present.
 * `cvmfs_yum`  Yum repository URL for cvmfs.
+* `cvmfs_yum_priority` Yum priority of repositories, defaults to 80.
 * `cvmfs_yum_proxy` http proxy for cvmfs yum package repository
 * `cvmfs_yum_config`  Yum repository URL for cvmfs site configs.
 * `cvmfs_yum_config_enabled`  Defaults to false, set to true to enable.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class cvmfs (
   String[1] $cvmfs_version                                       = 'present',
   Stdlib::Httpurl $cvmfs_yum                                     = "http://cern.ch/cvmrepo/yum/cvmfs/EL/${::operatingsystemmajrelease}/${::architecture}",
   Stdlib::Httpurl $cvmfs_yum_config                              = "http://cern.ch/cvmrepo/yum/cvmfs-config/EL/${::operatingsystemmajrelease}/${::architecture}",
+  Integer $cvmfs_yum_priority                                    = 80,
   Integer[0,1] $cvmfs_yum_config_enabled                            = 0,
   Optional[Stdlib::Httpurl] $cvmfs_yum_proxy                     = undef,
   Stdlib::Httpurl $cvmfs_yum_testing                             = "http://cern.ch/cvmrepo/yum/cvmfs-testing/EL/${::operatingsystemmajrelease}/${::architecture}",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,7 +20,6 @@ class cvmfs::install (
   $cvmfs_version = $cvmfs::cvmfs_version,
   $cvmfs_cache_base = $cvmfs::cvmfs_cache_base,
   $cvmfs_yum_manage_repo = $cvmfs::cvmfs_yum_manage_repo,
-
 ) inherits cvmfs {
 
   if $cvmfs_yum_manage_repo {

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -20,6 +20,7 @@ class cvmfs::yum (
   $cvmfs_yum_proxy = $cvmfs::cvmfs_yum_proxy,
   $cvmfs_yum_gpgcheck = $cvmfs::cvmfs_yum_gpgcheck,
   $cvmfs_yum_gpgkey = $cvmfs::cvmfs_yum_gpgkey,
+  Integer $cvmfs_yum_priority = $cvmfs::cvmfs_yum_priority,
 )  inherits cvmfs {
 
   yumrepo{'cvmfs':
@@ -29,7 +30,7 @@ class cvmfs::yum (
     gpgkey      => $cvmfs_yum_gpgkey,
     enabled     => 1,
     includepkgs => 'cvmfs,cvmfs-keys,cvmfs-server,cvmfs-config-default',
-    priority    => 80,
+    priority    => $cvmfs_yum_priority,
     require     => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'],
     proxy       => $cvmfs_yum_proxy,
   }
@@ -40,7 +41,7 @@ class cvmfs::yum (
     gpgkey      => $cvmfs_yum_gpgkey,
     enabled     => $cvmfs_yum_testing_enabled,
     includepkgs => 'cvmfs,cvmfs-keys,cvmfs-server,cvmfs-config-default',
-    priority    => 80,
+    priority    => $cvmfs_yum_priority,
     require     => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'],
     proxy       => $cvmfs_yum_proxy,
   }
@@ -50,7 +51,7 @@ class cvmfs::yum (
     gpgcheck => $cvmfs_yum_gpgcheck,
     gpgkey   => $cvmfs_yum_gpgkey,
     enabled  => $cvmfs_yum_config_enabled,
-    priority => 80,
+    priority => $cvmfs_yum_priority,
     require  => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'],
     proxy    => $cvmfs_yum_proxy,
   }

--- a/spec/classes/cvmfs_spec.rb
+++ b/spec/classes/cvmfs_spec.rb
@@ -73,7 +73,9 @@ describe 'cvmfs' do
           'enabled' => '1',
           'baseurl' => 'http://cern.ch/cvmrepo/yum/cvmfs/EL/7/x86_64',
           'gpgcheck' => 1,
-          'gpgkey'   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'
+          'gpgkey'   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM',
+          'priority' => 80
+
         )
       end
       it do
@@ -121,15 +123,19 @@ describe 'cvmfs' do
         it { is_expected.to contain_concat__fragment('cvmfs_default_local_header').with_content(%r{^CVMFS_QUOTA_LIMIT='5000000'$}) }
       end
 
-      context 'with cvmfs_yum_gpgcheck set to 0' do
+      context 'with cvmfs_yum_gpgcheck set to 0 and yum_priority 100' do
         let(:params) do
           { cvmfs_yum_gpgcheck: 0,
+            cvmfs_yum_priority: 100,
             cvmfs_http_proxy: :undef }
         end
 
         it { is_expected.to contain_yumrepo('cvmfs').with_gpgcheck(0) }
+        it { is_expected.to contain_yumrepo('cvmfs').with_priority(100) }
         it { is_expected.to contain_yumrepo('cvmfs-testing').with_gpgcheck(0) }
+        it { is_expected.to contain_yumrepo('cvmfs-testing').with_priority(100) }
         it { is_expected.to contain_yumrepo('cvmfs-config').with_gpgcheck(0) }
+        it { is_expected.to contain_yumrepo('cvmfs-config').with_priority(100) }
       end
 
       context 'with cvmfs_yum_gpgkey set to http://example.org/key.gpg' do


### PR DESCRIPTION
New `cvmfs_yum_priority` parameter which
defaults to `80`. If set will specify
priority of each yum repository. The current
hard code value is 80 so backwards compatable.
Fixes #67
