### PR TITLE
New dns_min,max_ttl variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ cvmfs::mount{'myrepo.example.org':
    you have allocated a partition to cvmfs cache.
 * `cvmfs_http_proxy` List of squid servers, see params.pp for default.
 * `cvmfs_cache_base` Location of the CVMFS cache base, see params.pp for default.
+* `cvmfs_dns_min_ttl` Minimum ttl of DNS lookups.
+* `cvmfs_dns_max_ttl` Maximum ttl of DNS lookups.
   `cvmfs_claim_ownership` Whether the client claims ownership of files or not, see params.pp for default.
 * `cvmfs_memcache_size` Size of the CernVM-FS meta-data memory cache in Megabyte.
 * `cvmfs_mount_rw` Mount option to mount read-only or read/write, 'yes|no', see params.pp for default.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,14 +11,16 @@
 # Copyright 2012 CERN
 #
 class cvmfs::config (
-  $mount_method           = $cvmfs::mount_method,
-  $manage_autofs_service  = $cvmfs::manage_autofs_service,
-  $cvmfs_quota_limit      = $cvmfs::cvmfs_quota_limit,
-  $cvmfs_quota_ratio      = $cvmfs::cvmfs_quota_ratio,
-  $cvmfs_repo_list        = $cvmfs::cvmfs_repo_list,
-  $cvmfs_memcache_size    = $cvmfs::cvmfs_memcache_size,
-  $cvmfs_claim_ownership  = $cvmfs::cvmfs_claim_ownership,
-  $default_cvmfs_partsize = $cvmfs::default_cvmfs_partsize,
+  $mount_method                        = $cvmfs::mount_method,
+  $manage_autofs_service               = $cvmfs::manage_autofs_service,
+  $cvmfs_quota_limit                   = $cvmfs::cvmfs_quota_limit,
+  $cvmfs_quota_ratio                   = $cvmfs::cvmfs_quota_ratio,
+  $cvmfs_repo_list                     = $cvmfs::cvmfs_repo_list,
+  $cvmfs_memcache_size                 = $cvmfs::cvmfs_memcache_size,
+  $cvmfs_claim_ownership               = $cvmfs::cvmfs_claim_ownership,
+  $default_cvmfs_partsize              = $cvmfs::default_cvmfs_partsize,
+  Optional[Integer] $cvmfs_dns_max_ttl = $cvmfs::cvmfs_dns_max_ttl,
+  Optional[Integer] $cvmfs_dns_min_ttl = $cvmfs::cvmfs_dns_min_ttl,
 ) inherits cvmfs {
 
   # If cvmfspartsize fact exists use it, otherwise use a sensible default.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,8 @@ class cvmfs (
   Optional[Enum['yes','no']] $cvmfs_follow_redirects             = undef,
   Boolean $cvmfs_yum_manage_repo                                 = true,
   Boolean $cvmfs_repo_list                                       = true,
+  Optional[Integer] $cvmfs_dns_min_ttl                           = undef,
+  Optional[Integer] $cvmfs_dns_max_ttl                           = undef,
 ) {
 
 

--- a/spec/classes/cvmfs_spec.rb
+++ b/spec/classes/cvmfs_spec.rb
@@ -193,6 +193,41 @@ describe 'cvmfs' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.not_to contain_service('autofs') }
       end
+
+      context 'with cvmfs_dns_min_ttl not set' do
+        it do
+          is_expected.to contain_concat__fragment('cvmfs_default_local_header').
+            without_content(%r{^CVMFS_DNS_MIN_TTL})
+        end
+      end
+      context 'with cvmfs_dns_min_ttl set to 20' do
+        let(:params) do
+          { cvmfs_dns_min_ttl: 20,
+            cvmfs_http_proxy: :undef }
+        end
+
+        it do
+          is_expected.to contain_concat__fragment('cvmfs_default_local_header').
+            with_content(%r{^CVMFS_DNS_MIN_TTL='20'$})
+        end
+      end
+      context 'with cvmfs_dns_max_ttl not set' do
+        it do
+          is_expected.to contain_concat__fragment('cvmfs_default_local_header').
+            without_content(%r{^CVMFS_DNS_MAX_TTL})
+        end
+      end
+      context 'with cvmfs_dns_max_ttl set to 200' do
+        let(:params) do
+          { cvmfs_dns_max_ttl: 200,
+            cvmfs_http_proxy: :undef }
+        end
+
+        it do
+          is_expected.to contain_concat__fragment('cvmfs_default_local_header').
+            with_content(%r{^CVMFS_DNS_MAX_TTL='200'$})
+        end
+      end
       context 'with cvmfs_mount_rw not set' do
         it do
           is_expected.to contain_concat__fragment('cvmfs_default_local_header').

--- a/templates/repo.local.erb
+++ b/templates/repo.local.erb
@@ -8,6 +8,12 @@
 # within the default.conf file.
 <% end -%>
 
+<% if @cvmfs_dns_max_ttl -%>
+CVMFS_DNS_MAX_TTL='<%= @cvmfs_dns_max_ttl %>'
+<% end -%>
+<% if @cvmfs_dns_min_ttl -%>
+CVMFS_DNS_MIN_TTL='<%= @cvmfs_dns_min_ttl %>'
+<% end -%>
 <% if @my_cvmfs_quota_limit and  @my_cvmfs_quota_limit != '' -%>
 CVMFS_QUOTA_LIMIT='<%= @my_cvmfs_quota_limit %>'
 <% end -%>


### PR DESCRIPTION
cvmfs 2.5.2 supports the configuration

* CVMFS_DNS_MIN_TTL
* CVMFS_DNS_MAX_TTL

these can now optioinally be set via.

* cvmfs::cvmfs_dns_min_ttl
* cvmfs::cvmfs_dns_max_ttl