### PR TITLE
yum: Allow to override includepkgs, default unchanged.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,7 @@ class cvmfs (
   Integer[0,1] $cvmfs_yum_testing_enabled                           = 0,
   Integer[0,1] $cvmfs_yum_gpgcheck                                  = 1,
   Variant[Stdlib::Filesource,Stdlib::Httpurl] $cvmfs_yum_gpgkey  = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM',
+  Variant[Enum['absent'], String] $cvmfs_yum_includepkgs         = 'cvmfs,cvmfs-keys,cvmfs-server,cvmfs-config-default',
   Optional[Enum['yes','no']] $cvmfs_use_geoapi                   = undef,
   Optional[Enum['yes','no']] $cvmfs_follow_redirects             = undef,
   Boolean $cvmfs_yum_manage_repo                                 = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,7 @@ class cvmfs (
   Integer[0,1] $cvmfs_yum_testing_enabled                           = 0,
   Integer[0,1] $cvmfs_yum_gpgcheck                                  = 1,
   Variant[Stdlib::Filesource,Stdlib::Httpurl] $cvmfs_yum_gpgkey  = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM',
-  Variant[Enum['absent'], String] $cvmfs_yum_includepkgs         = 'cvmfs,cvmfs-keys,cvmfs-server,cvmfs-config-default',
+  Variant[Enum['absent'], Array[String]] $cvmfs_yum_includepkgs  = ['cvmfs','cvmfs-keys','cvmfs-server','cvmfs-config-default'],
   Optional[Enum['yes','no']] $cvmfs_use_geoapi                   = undef,
   Optional[Enum['yes','no']] $cvmfs_follow_redirects             = undef,
   Boolean $cvmfs_yum_manage_repo                                 = true,

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -24,13 +24,19 @@ class cvmfs::yum (
   Integer $cvmfs_yum_priority = $cvmfs::cvmfs_yum_priority,
 )  inherits cvmfs {
 
+  if $cvmfs_yum_includepkgs =~ Array[String] {
+    $yum_includepkgs = join($cvmfs_yum_includepkgs, ' ')
+  } else {
+    $yum_includepkgs = $cvmfs_yum_includepkgs
+  }
+
   yumrepo{'cvmfs':
     descr       => "CVMFS yum repository for el${::operatingsystemmajrelease}",
     baseurl     => $cvmfs_yum,
     gpgcheck    => $cvmfs_yum_gpgcheck,
     gpgkey      => $cvmfs_yum_gpgkey,
     enabled     => 1,
-    includepkgs => $cvmfs_yum_includepkgs,
+    includepkgs => $yum_includepkgs,
     priority    => $cvmfs_yum_priority,
     require     => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'],
     proxy       => $cvmfs_yum_proxy,
@@ -41,7 +47,7 @@ class cvmfs::yum (
     gpgcheck    => $cvmfs_yum_gpgcheck,
     gpgkey      => $cvmfs_yum_gpgkey,
     enabled     => $cvmfs_yum_testing_enabled,
-    includepkgs => $cvmfs_yum_includepkgs,
+    includepkgs => $yum_includepkgs,
     priority    => $cvmfs_yum_priority,
     require     => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'],
     proxy       => $cvmfs_yum_proxy,

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -20,6 +20,7 @@ class cvmfs::yum (
   $cvmfs_yum_proxy = $cvmfs::cvmfs_yum_proxy,
   $cvmfs_yum_gpgcheck = $cvmfs::cvmfs_yum_gpgcheck,
   $cvmfs_yum_gpgkey = $cvmfs::cvmfs_yum_gpgkey,
+  $cvmfs_yum_includepkgs = $cvmfs::cvmfs_yum_includepkgs,
   Integer $cvmfs_yum_priority = $cvmfs::cvmfs_yum_priority,
 )  inherits cvmfs {
 
@@ -29,7 +30,7 @@ class cvmfs::yum (
     gpgcheck    => $cvmfs_yum_gpgcheck,
     gpgkey      => $cvmfs_yum_gpgkey,
     enabled     => 1,
-    includepkgs => 'cvmfs,cvmfs-keys,cvmfs-server,cvmfs-config-default',
+    includepkgs => $cvmfs_yum_includepkgs,
     priority    => $cvmfs_yum_priority,
     require     => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'],
     proxy       => $cvmfs_yum_proxy,
@@ -40,7 +41,7 @@ class cvmfs::yum (
     gpgcheck    => $cvmfs_yum_gpgcheck,
     gpgkey      => $cvmfs_yum_gpgkey,
     enabled     => $cvmfs_yum_testing_enabled,
-    includepkgs => 'cvmfs,cvmfs-keys,cvmfs-server,cvmfs-config-default',
+    includepkgs => $cvmfs_yum_includepkgs,
     priority    => $cvmfs_yum_priority,
     require     => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM'],
     proxy       => $cvmfs_yum_proxy,


### PR DESCRIPTION
The default is fine for standard use cases (server, client),
but does not allow to adopt new CVMFS tools outside of this module
(cvmfs-gateway, cvmfs-shrinkwrap etc.) without turning off
managerepo. This commit allows the user to override includepkgs.