### PR TITLE
Drop files in autofs.master.d must end in .autofs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,12 @@ matrix:
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
     services: docker
     sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos8-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,18 @@ matrix:
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos8-64{hypervisor=docker} CHECK=beaker
     services: docker
     sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos8-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
 branches:
   only:
   - master

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -111,7 +111,7 @@ class cvmfs::config (
         onlyif  => 'match *[map="/etc/auto.cvmfs"] size == 0',
       }
     } else {
-      file{'/etc/auto.master.d/cvmfs.conf':
+      file{'/etc/auto.master.d/cvmfs.autofs':
         ensure  => file,
         content => "Puppet installed\n/cvmfs  program:/etc/auto.cvmfs\n",
         owner   => root,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -89,9 +89,9 @@ describe 'cvmfs' do
             case facts[:os]['release']['major']
             when '6', '7'
               it { is_expected.to contain_augeas('cvmfs_automaster') }
-              it { is_expected.not_to contain_file('/etc/auto.master.d/cvmfs.conf') }
+              it { is_expected.not_to contain_file('/etc/auto.master.d/cvmfs.autofs') }
             else
-              it { is_expected.to contain_file('/etc/auto.master.d/cvmfs.conf') }
+              it { is_expected.to contain_file('/etc/auto.master.d/cvmfs.autofs') }
               it { is_expected.not_to contain_augeas('cvmfs_automaster') }
             end
           end
@@ -104,7 +104,7 @@ describe 'cvmfs' do
 
             it { is_expected.to compile.with_all_deps }
             it { is_expected.not_to contain_service('autofs') }
-            it { is_expected.not_to contain_file('/etc/auto.master.d/cvmfs.conf') }
+            it { is_expected.not_to contain_file('/etc/auto.master.d/cvmfs.autofs') }
             it { is_expected.not_to contain_augeas('cvmfs_automaster') }
           end
 


### PR DESCRIPTION
The file `/etc/autofs.master.d/cvmfs.conf` was being created and due to poor testing environment I missed that does not work. Files must end in .autofs.

Only affects CentOS 8 and newer.

Also enable CentOS 8 acceptance tests which would have spotted this in the first place.
