### PR TITLE
cvmfs::fsck: Enable cvmfs-fsck.timer.

### DIFF
--- a/manifests/fsck.pp
+++ b/manifests/fsck.pp
@@ -22,6 +22,7 @@ class cvmfs::fsck (
       {
         'onreboot' => $onreboot,
       }),
+      enable  => true,
       active  => true,
     }
     systemd::unit_file{'cvmfs-fsck.service':


### PR DESCRIPTION
Up to now, it was only activated on each Puppet run,
and not enabled for good.

Tested on a real Ubuntu 18.04 system, works as expected. 
Closes #99 . 