### PR TITLE
Remove limits module and usage

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -50,18 +50,6 @@ class cvmfs::server::config (
     require    => Group[$user],
   }
 
-  ::limits::entry{'shared-soft':
-    type   => 'soft',
-    item   => 'nofile',
-    value  => $nofiles,
-    domain => 'shared',}
-  ::limits::entry{'shared-hard':
-    type   => 'hard',
-    item   => 'nofile',
-    value  => $nofiles,
-    domain => 'shared',
-  }
-
   exec{'cvmfs_mkfs':
     command => "/usr/bin/cvmfs_server mkfs -o ${user} ${repo}",
     creates => "/etc/cvmfs/repositories.d/${repo}",

--- a/metadata.json
+++ b/metadata.json
@@ -19,10 +19,6 @@
       "version_requirement": ">=1.0.0 < 2.0.0",
       "name": "puppetlabs/firewall"
     },
-    {
-      "version_requirement": ">=0.3.1 < 1.0.0",
-      "name": "erwbgy/limits"
-    }
   ],
 
   "operatingsystem_support": [


### PR DESCRIPTION
The file limits were being set by a deprecated module
and would not have been applied anyway on CentOS 7.

Remove redundant limits configuration.

In addition it is intended to completly drop all sevrer code as well.

Fixes #95 