### PR TITLE
New cvmfs_instrument_fuse parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class cvmfs (
   Variant[Enum['absent'], Array[String]] $cvmfs_yum_includepkgs  = ['cvmfs','cvmfs-keys','cvmfs-server','cvmfs-config-default'],
   Optional[Enum['yes','no']] $cvmfs_use_geoapi                   = undef,
   Optional[Enum['yes','no']] $cvmfs_follow_redirects             = undef,
+  Boolean $cvmfs_instrument_fuse                                 = false,
   Boolean $cvmfs_yum_manage_repo                                 = true,
   Boolean $cvmfs_repo_list                                       = true,
   Optional[Integer] $cvmfs_dns_min_ttl                           = undef,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,6 +16,7 @@ describe 'cvmfs' do
         it { is_expected.to contain_class('cvmfs::service') }
         it { is_expected.to contain_package('cvmfs').with_ensure('present') }
         it { is_expected.to contain_package('cvmfs').with_require('Class[Cvmfs::Yum]') }
+        it { is_expected.to contain_concat__fragment('cvmfs_default_local_header').without_content(%r{^CVMFS_INSTRUMENT_FUSE.*$}) }
 
         context 'with defaults and cvmfspartsize fact unset' do
           it { is_expected.to contain_class('cvmfs::config') }
@@ -241,6 +242,30 @@ describe 'cvmfs' do
                 with_content(%r{^CVMFS_DNS_MAX_TTL='200'$})
             end
           end
+          context 'with cvmfs_instrument_fuse set true' do
+            let(:params) do
+              { cvmfs_instrument_fuse: true,
+                cvmfs_http_proxy: :undef }
+            end
+
+            it do
+              is_expected.to contain_concat__fragment('cvmfs_default_local_header').
+                with_content(%r{^CVMFS_INSTRUMENT_FUSE=true$})
+            end
+          end
+
+          context 'with cvmfs_instrument_fuse set false' do
+            let(:params) do
+              { cvmfs_instrument_fuse: false,
+                cvmfs_http_proxy: :undef }
+            end
+
+            it do
+              is_expected.not_to contain_concat__fragment('cvmfs_default_local_header').
+                with_content(%r{^CVMFS_INSTRUMENT_FUSE.*$})
+            end
+          end
+
           context 'with cvmfs_mount_rw not set' do
             it do
               is_expected.to contain_concat__fragment('cvmfs_default_local_header').

--- a/templates/repo.local.erb
+++ b/templates/repo.local.erb
@@ -90,4 +90,7 @@ CVMFS_ALIEN_CACHE='<%= @cvmfs_alien_cache %>'
 <% if @cvmfs_shared_cache -%>
 CVMFS_SHARED_CACHE='<%= @cvmfs_shared_cache %>'
 <% end -%>
+<% if @cvmfs_instrument_fuse -%>
+CVMFS_INSTRUMENT_FUSE=true
+<% end -%>
 <%end-%>


### PR DESCRIPTION
By default false if it is set true

CVMFS_INSTRUMENT_FUSE=true will be specified.

https://cvmfs.readthedocs.io/en/stable/cpt-releasenotes.html#client-performance-instrumentation