### PR TITLE
add missing package require for file ownership

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,6 +41,7 @@ class cvmfs::install (
       group   => cvmfs,
       mode    => '0700',
       seltype => $cache_seltype,
+      require => Package['cvmfs']
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,7 +41,7 @@ class cvmfs::install (
       group   => cvmfs,
       mode    => '0700',
       seltype => $cache_seltype,
-      require => Package['cvmfs']
+      require => Package['cvmfs'],
     }
   }
 


### PR DESCRIPTION
The cvmfs_cache_base file resource does a chown to cvmfs user without requiring that user, created by the cvmfs package, causing issues on 1st puppet run. Fix that. 