### PR TITLE
Support per mount CVMFS_REPOSITORY_TAG specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ cvmfs::mount{'cms.example.org':
 * `mount_options` If the *mount_method* is *mount* then this specifies the mount
    options. By default: `nodev,_netdev,defaults`.
 * `cvmfs_memcache_size` Size of the CernVM-FS meta-data memory cache in Megabyte.
+* `cvmfs_repository_tag` Specify a tag , sets `CVMFS_REPOSITORY_TAG`
 * TBC
 
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -22,6 +22,7 @@ define cvmfs::mount($cvmfs_quota_limit = undef,
   Optional[Integer] $cvmfs_external_timeout = undef,
   Optional[Integer] $cvmfs_external_timeout_direct = undef,
   Optional[String] $cvmfs_external_url = undef,
+  Optional[String[1]] $cvmfs_repository_tag = undef,
 ) {
 
   include ::cvmfs

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -24,6 +24,7 @@ describe 'cvmfs::mount' do
         it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without_content(%r{.*CVMFS_USE_GEOAPI.*$}) }
         it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without_content(%r{.*CVMFS_FOLLOW_REDIRECTS.*$}) }
         it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without_content(%r{.*CVMFS_CLAIM_OWNERSHIP.*$}) }
+        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without_content(%r{.*CVMFS_REPOSITORY_TAG.*$}) }
         it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without('content' => %r{^CVMFS_HTTP_PROXY.*$}) }
         context 'with lots of  parameters set' do
           let(:params) do
@@ -31,7 +32,8 @@ describe 'cvmfs::mount' do
               cvmfs_use_geoapi: 'yes',
               cvmfs_follow_redirects: 'yes',
               cvmfs_memcache_size: 2000,
-              cvmfs_claim_ownership: 'yes'
+              cvmfs_claim_ownership: 'yes',
+              cvmfs_repository_tag: 'testing'
             }
           end
 
@@ -39,6 +41,7 @@ describe 'cvmfs::mount' do
           it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_USE_GEOAPI='yes'$}) }
           it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_FOLLOW_REDIRECTS='yes'$}) }
           it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_CLAIM_OWNERSHIP='yes'$}) }
+          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_REPOSITORY_TAG='testing'$}) }
         end
       end
     end

--- a/templates/repo.local.erb
+++ b/templates/repo.local.erb
@@ -68,6 +68,9 @@ CVMFS_FOLLOW_REDIRECTS='<%= @cvmfs_follow_redirects %>'
 <% if @cvmfs_external_fallback_proxy -%>
 CVMFS_EXTERNAL_FALLBACK_PROXY='<%= @cvmfs_external_fallback_proxy %>'
 <% end -%>
+<% if @cvmfs_repository_tag -%>
+CVMFS_REPOSITORY_TAG='<%= @cvmfs_repository_tag %>'
+<% end -%>
 <% if @cvmfs_external_http_proxy -%>
 CVMFS_EXTERNAL_HTTP_PROXY='<%= @cvmfs_external_http_proxy %>'
 <% end -%>


### PR DESCRIPTION
For individual mounts a CVMFS_REPOSITORY_TAG can now be specified.