### PR TITLE
New cvmfs_repositories parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ cvmfs::mount{'myrepo.example.org':
 * `cvmfs_yum_gpgkey`  Set a custom GPG key for yum repos, you must deploy it yourself.
 * `cvmfs_yum_manage_repo` Defaults to true, set to false to disable yum repositories management.
 * `cvmfs_use_geoapi`  **TO DOC**
-
+* `cvmfs_repositories` By default undef and `CVMFS_REPOSITORIES` in `default.local` will be populated
+   automatically from what is explicitly mounted with `cvmfs::mount`. If this is 
+   specified then`CVMFS_REPOSITORIES` list in `default.local` will be exactly managed with this variable.
+   e.g `cvmfs-config.cern.ch,atlas.cern.ch`
 * `cvmfs_hash` Rather than using cvmfs::mount defined type a hash of mounts can be sepecfied.
    cvmfs_hash {'myrepo' => {'cvmfs_server_url' => 'http://web.example.org/cvmfs/ams.example.org/}
 * `cvmfs_env_variables`  $cvmfs_env_variables = {'CMS_LOCAL_SITE' => '<path to siteconf>'
@@ -141,7 +144,8 @@ cvmfs::mount{'cms.example.org':
 * `namevar`  The namevar is the repository name, e.g atlas.example.ch
 * `cvmfs_repo_list` A boolean defaults to `true`. Should this repository be 
    included in the list of repositories listed as `CVMFS_REPOSITORIES`
-   with `/etc/cvmfs/default.local`.
+   with `/etc/cvmfs/default.local`. This is ignored if `cvmfs_repositories` is
+   set on the main class.
 * `cvmfs_follow_redirects` Sets CVMFS_FOLLOW_REDIRECTS to its value, by default unset.
 * `mount_options` If the *mount_method* is *mount* then this specifies the mount
    options. By default: `nodev,_netdev,defaults`.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,6 +21,7 @@ class cvmfs::config (
   $default_cvmfs_partsize              = $cvmfs::default_cvmfs_partsize,
   Optional[Integer] $cvmfs_dns_max_ttl = $cvmfs::cvmfs_dns_max_ttl,
   Optional[Integer] $cvmfs_dns_min_ttl = $cvmfs::cvmfs_dns_min_ttl,
+  $cvmfs_repositories                  = $cvmfs::cvmfs_repositories,
 ) inherits cvmfs {
 
   # If cvmfspartsize fact exists use it, otherwise use a sensible default.
@@ -84,7 +85,14 @@ class cvmfs::config (
     order   => 0,
     content => template('cvmfs/repo.local.erb'),
   }
-  if $cvmfs_repo_list {
+
+  if $cvmfs_repositories {
+    concat::fragment{'cvmfs_default_local_repo':
+      target  => '/etc/cvmfs/default.local',
+      order   => 5,
+      content => "CVMFS_REPOSITORIES='${cvmfs_repositories}'\n",
+    }
+  } elsif $cvmfs_repo_list {
     concat::fragment{'cvmfs_default_local_repo_end':
       target  => '/etc/cvmfs/default.local',
       order   => 7,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,8 @@ class cvmfs (
   Optional[Integer] $cvmfs_dns_min_ttl                           = undef,
   Optional[Integer] $cvmfs_dns_max_ttl                           = undef,
   Optional[String] $cvmfs_alien_cache                            = undef,
-  Optional[Enum['yes','no']] $cvmfs_shared_cache                 = undef
+  Optional[Enum['yes','no']] $cvmfs_shared_cache                 = undef,
+  Optional[String[1]] $cvmfs_repositories                        = undef,
 ) {
 
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -37,7 +37,7 @@ define cvmfs::mount($cvmfs_quota_limit = undef,
     require => Class['cvmfs::install'],
     notify  => Class['cvmfs::service'],
   }
-  if $cvmfs_repo_list {
+  if $cvmfs_repo_list and $cvmfs::cvmfs_repositories =~ Undef {
     concat::fragment{"cvmfs_default_local_${repo}":
       target  => '/etc/cvmfs/default.local',
       order   => 6,


### PR DESCRIPTION
Normally `CVMFS_REPOSITORIES` in `/etc/cvmfs/default.local` is
populated from explicit cvmfs::mount instances depending on
the cvmfs_repo_list boolean per mount.

If `cvmfs_repositories` is specified then all values of `cvmfs_repo_list`
will be ignored and the CVMFS_REPOSITORIES will be exactly set to the
value of the new parameter.

This is useful when wanting to control which repositories will be probed
with cvmfs_config probe for instance.