### PR TITLE
Support Debian 13

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -10,32 +10,80 @@ class cvmfs::apt (
   Boolean $repo_gpgcheck                                                = $cvmfs::repo_gpgcheck,
 ) {
   # We already reject arrays of more than one element in init.pp
-  $_location = Array($repo_base,true)[0]
 
-  Apt::Source {
-    allow_insecure => ! $repo_gpgcheck,
-    comment        => 'CernVM File System',
-    location       => $_location,
-    key            => {
+  if ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'],'12') <= 0 ) or
+  ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'],'24.04') <= 0 ) {
+    $_source_format = 'list'
+    $_key           = {
       ensure  => refreshed,
       id      => 'FD80468D49B3B24C341741FC8CE0A76C497EA957',
       source  => $repo_gpgkey,
-    },
-    repos          => 'main',
+    }
+    $_keyring = undef
+    $_location = Array($repo_base,true)[0] # Take first one for old format.
+    $_release_cvmfs = "${facts['os']['distro']['codename']}-prod"
+    $_release_testing = "${facts['os']['distro']['codename']}-testing"
+    $_release_future = "${facts['os']['distro']['codename']}-future"
+    $_repos = 'main'
+
+    # These _ensure and _enabled parameters
+    # https://github.com/puppetlabs/puppetlabs-apt/pull/1243
+    # You cannot use "ensure"  => absent with format 'sources'.
+    # You cannot use "enabled" => ... with format 'list'.
+    #
+    $_repo_testing_ensure = bool2str($repo_testing_enabled,'present','absent')
+    $_repo_future_ensure = bool2str($repo_future_enabled,'present','absent')
+    $_repo_testing_enabled = undef
+    $_repo_future_enabled = undef
+  } else { # deb822
+
+    $_source_format = 'sources'
+    $_location = Array($repo_base,true)
+    $_release_cvmfs = ["${facts['os']['distro']['codename']}-prod"]
+    $_release_testing = ["${facts['os']['distro']['codename']}-testing"]
+    $_release_future = ["${facts['os']['distro']['codename']}-future"]
+    $_repos = ['main']
+
+    $_key = undef
+    $_keyring = '/etc/apt/keyrings/cernvm.gpg'
+
+    # see above
+    $_repo_testing_ensure = 'present'
+    $_repo_future_ensure = 'present'
+    $_repo_testing_enabled = $repo_testing_enabled
+    $_repo_future_enabled = $repo_future_enabled
+
+    apt::keyring { 'cernvm.gpg':
+      source => $repo_gpgkey,
+      before => [Apt::Source['cvmfs'],Apt::Source['cvmfs-testing'],Apt::Source['cvmfs-future']],
+    }
+  }
+
+  Apt::Source {
+    comment        => 'CernVM File System',
+    source_format  => $_source_format,
+    allow_insecure => ! $repo_gpgcheck,
+    location       => $_location,
+    key            => $_key,
+    keyring        => $_keyring,
+    repos          => $_repos,
     notify_update  => true,
   }
 
   apt::source { 'cvmfs':
     ensure  => 'present',
-    release => "${facts['os']['distro']['codename']}-prod",
+    release => $_release_cvmfs,
   }
 
   apt::source { 'cvmfs-testing':
-    ensure  => bool2str($repo_testing_enabled,'present','absent'),
-    release => "${facts['os']['distro']['codename']}-testing",
+    ensure  => $_repo_testing_ensure,
+    release => $_release_testing,
+    enabled => $_repo_testing_enabled,
   }
+
   apt::source { 'cvmfs-future':
-    ensure  => bool2str($repo_future_enabled,'present','absent'),
-    release => "${facts['os']['distro']['codename']}-future",
+    ensure  => $_repo_future_ensure,
+    release => $_release_future,
+    enabled => $_repo_future_enabled,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": [
     {
-      "version_requirement": ">= 7.0.0 < 11.0.0",
+      "version_requirement": ">= 10.0.0 < 11.0.0",
       "name": "puppetlabs/apt"
     },
     {
@@ -29,7 +29,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "11",
-        "12"
+        "12",
+        "13"
       ]
     },
     {


### PR DESCRIPTION
#### Pull Request (PR) description

Support Debian 13 
With debian 13 and what will be Ubuntu 26.04 we switch to deb822 sources format.

The minimum version of puppetlabs-apt is increased to version 10
to support deb822 format.

