### PR TITLE
Control apt's Allow-Insecure and not Trusted

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -13,7 +13,7 @@ class cvmfs::apt (
   $_location = Array($repo_base,true)[0]
 
   Apt::Source {
-    allow_unsigned => ! $repo_gpgcheck,
+    allow_insecure => ! $repo_gpgcheck,
     comment        => 'CernVM File System',
     location       => $_location,
     key            => {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -169,7 +169,8 @@ describe 'cvmfs' do
                     'ensure' => 'present',
                     'location' => 'https://cvmrepo.s3.cern.ch/cvmrepo/apt',
                     'release' => 'bookworm-prod',
-                    'allow_unsigned' => false,
+                    'allow_insecure' => false,
+                    'allow_unsigned' => nil,
                   }
                 )
               }
@@ -180,7 +181,8 @@ describe 'cvmfs' do
                     'ensure' => 'absent',
                     'location' => 'https://cvmrepo.s3.cern.ch/cvmrepo/apt',
                     'release' => 'bookworm-testing',
-                    'allow_unsigned' => false,
+                    'allow_insecure' => false,
+                    'allow_unsigned' => nil,
                   }
                 )
               }
@@ -336,8 +338,8 @@ describe 'cvmfs' do
               it { is_expected.to contain_yumrepo('cvmfs-config').with_gpgcheck(false) }
               it { is_expected.to contain_yumrepo('cvmfs-config').with_priority(100) }
             else
-              it { is_expected.to contain_apt__source('cvmfs').with_allow_unsigned(true) }
-              it { is_expected.to contain_apt__source('cvmfs-testing').with_allow_unsigned(true) }
+              it { is_expected.to contain_apt__source('cvmfs').with_allow_insecure(true).without_untrusted }
+              it { is_expected.to contain_apt__source('cvmfs-testing').with_allow_insecure(true).without_untrusted }
             end
           end
 


### PR DESCRIPTION
#### Pull Request (PR) description

The `repo_gpgcheck` parameter was being ignored on all apt repositories. It set the `allow_unsigned` parameter to `apt::sources` but that is ignored on pre deb822 configurations.

The default apt configuration was in use always to check apt repositories were secure in the gpg sense.

Set `apt::source`'s  `allow_insecure` parameter to yes if `repo_gpgcheck` is `false`.
