### PR TITLE
Typo in .sync.yml file

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -6,6 +6,6 @@ spec/spec_helper_acceptance.rb:
 # autofs module does not work with rootless podman
 # try again post Ubuntu 24.04, podman 4 github runners
 #
-github/workflows/ci.yml:
+.github/workflows/ci.yml:
   with:
     beaker_hypervisor: 'container_docker'


### PR DESCRIPTION
#### Pull Request (PR) description

This is causing modulesync_config CI to fail.


```
Syncing 'puppet-cvmfs'
puppet-cvmfs: Error while rendering file: 'github/workflows/ci.yml'
bundler: failed to load command: msync (/home/runner/work/modulesync_config/modulesync_config/vendor/bundle/ruby/2.7.0/bin/msync)
/home/runner/work/modulesync_config/modulesync_config/vendor/bundle/ruby/2.7.0/gems/modulesync-3.5.0/lib/modulesync/renderer.rb:16:in `read': No such file or directory @ rb_sysopen - ./moduleroot/github/workflows/ci.yml.erb (Errno::ENOENT)
```