### PR TITLE
Add second apt repository for failover on Debian 13

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -409,7 +409,7 @@ Default value: `'present'`
 
 Data type: `Variant[Stdlib::Httpurl,Array[Stdlib::Httpurl,1]]`
 
-URL containing stable, testing and config apt or yum repositories. If an array is specified then on RedHat family multiple repos will be configured with failover. On Debian family the array can have length 1 only, failover is not supported for Debian.
+URL containing stable, testing and config apt or yum repositories. If an array is specified then on RedHat family or Debian 13 or newer multiple repos will be configured with failover. For older Debian and Ubuntu only one repository can be configured.
 
 ##### <a name="-cvmfs--repo_base_alt"></a>`repo_base_alt`
 

--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -1,5 +1,7 @@
 ---
 
-cvmfs::repo_base:   https://cvmrepo.s3.cern.ch/cvmrepo/apt
+cvmfs::repo_base:
+  - 'https://cvmrepo.s3.cern.ch/cvmrepo/apt'
+  - 'https://cvmrepo.web.cern.ch/cvmrepo/apt'
 cvmfs::repo_base_alt:   https://cvmrepo.web.cern.ch/cvmrepo/apt
 cvmfs::repo_gpgkey: https://cvmrepo.s3.cern.ch/cvmrepo/apt/cernvm.gpg

--- a/data/name/Debian/11.yaml
+++ b/data/name/Debian/11.yaml
@@ -1,0 +1,2 @@
+---
+cvmfs::repo_base: 'https://cvmrepo.s3.cern.ch/cvmrepo/apt'

--- a/data/name/Debian/12.yaml
+++ b/data/name/Debian/12.yaml
@@ -1,0 +1,2 @@
+---
+cvmfs::repo_base: 'https://cvmrepo.s3.cern.ch/cvmrepo/apt'

--- a/data/name/Ubuntu/22.04.yaml
+++ b/data/name/Ubuntu/22.04.yaml
@@ -1,0 +1,2 @@
+---
+cvmfs::repo_base: 'https://cvmrepo.s3.cern.ch/cvmrepo/apt'

--- a/data/name/Ubuntu/24.04.yaml
+++ b/data/name/Ubuntu/24.04.yaml
@@ -1,0 +1,2 @@
+---
+cvmfs::repo_base: 'https://cvmrepo.s3.cern.ch/cvmrepo/apt'

--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -9,8 +9,6 @@ class cvmfs::apt (
   Optional[Stdlib::Httpurl] $repo_proxy                                 = $cvmfs::repo_proxy,
   Boolean $repo_gpgcheck                                                = $cvmfs::repo_gpgcheck,
 ) {
-  # We already reject arrays of more than one element in init.pp
-
   if ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'],'12') <= 0 ) or
   ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'],'24.04') <= 0 ) {
     $_source_format = 'list'
@@ -20,6 +18,7 @@ class cvmfs::apt (
       source  => $repo_gpgkey,
     }
     $_keyring = undef
+    # We already reject arrays of more than one element in init.pp
     $_location = Array($repo_base,true)[0] # Take first one for old format.
     $_release_cvmfs = "${facts['os']['distro']['codename']}-prod"
     $_release_testing = "${facts['os']['distro']['codename']}-testing"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,7 @@
 # @param cvmfs_max_ttl Max ttl.
 # @param cvmfs_version Version of cvmfs to install.
 # @param repo_base
-#   URL containing stable, testing and config apt or yum repositories. If an array is specified then on RedHat family multiple repos will be configured with failover. On Debian family the array can have length 1 only, failover is not supported for Debian.
+#   URL containing stable, testing and config apt or yum repositories. If an array is specified then on RedHat family or Debian 13 or newer multiple repos will be configured with failover. For older Debian and Ubuntu only one repository can be configured.
 # @param repo_base_alt URL containing stable, Same as repo_base, hosted on a different backend. Default in hiera data.
 # @param repo_includepkgs Specify an includepkgs to the yum repos to ignore other packages.
 # @param repo_priority Yum priority of repositories
@@ -242,8 +242,11 @@ class cvmfs (
   }
 
   # Unsupported combinations
-  if $facts['os']['family'] == 'Debian' and $repo_base =~ Array[Any,2] {
-    fail('With Debian family OSes only a single url for the \"repo_base\" parameter is supported')
+  if (
+    ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'],'12') <= 0 ) or
+    ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'],'24.04') <= 0 )
+  ) and $repo_base =~ Array[Any,2] {
+    fail('With Debian 11, 12 or Ubuntu 22.04, 24.04 only a single url for the \"repo_base\" parameter is supported')
   }
 
   if $repo_manage {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -264,21 +264,30 @@ describe 'cvmfs' do
                   {
                     ensure: 'present',
                     enabled: true,
-                    location: ['https://cvmrepo.s3.cern.ch/cvmrepo/apt'],
+                    location: [
+                      'https://cvmrepo.s3.cern.ch/cvmrepo/apt',
+                      'https://cvmrepo.web.cern.ch/cvmrepo/apt',
+                    ],
                   }
                 )
                 is_expected.to contain_apt__source('cvmfs-testing').with(
                   {
                     ensure: 'present',
                     enabled: false,
-                    location: ['https://cvmrepo.s3.cern.ch/cvmrepo/apt'],
+                    location: [
+                      'https://cvmrepo.s3.cern.ch/cvmrepo/apt',
+                      'https://cvmrepo.web.cern.ch/cvmrepo/apt',
+                    ],
                   }
                 )
                 is_expected.to contain_apt__source('cvmfs-future').with(
                   {
                     ensure: 'present',
                     enabled: false,
-                    location: ['https://cvmrepo.s3.cern.ch/cvmrepo/apt'],
+                    location: [
+                      'https://cvmrepo.s3.cern.ch/cvmrepo/apt',
+                      'https://cvmrepo.web.cern.ch/cvmrepo/apt',
+                    ],
                   }
                 )
               }
@@ -418,7 +427,24 @@ describe 'cvmfs' do
               it { is_expected.to contain_yumrepo('cvmfs-testing').with_baseurl(%r{^http://example.org/base/cvmfs-testing/(EL|fedora)/\d+/x86_64 http://example.net/base/cvmfs-testing/(EL|fedora)/\d+/x86_64$}) }
               it { is_expected.to contain_yumrepo('cvmfs-config').with_baseurl(%r{^http://example.org/base/cvmfs-config/(EL|fedora)/\d+/x86_64 http://example.net/base/cvmfs-config/(EL|fedora)/\d+/x86_64$}) }
             else
-              it { is_expected.to compile.and_raise_error(%r{Debian family OSes only a single url}) }
+              case [facts[:os]['name'], facts[:os]['release']['major']]
+              when %w[Debian 11], %w[Debian 12], ['Ubuntu', '22.04'], ['Ubuntu', '24.04']
+                it { is_expected.to compile.and_raise_error(%r{only a single url for the}) }
+              else
+                it {
+                  is_expected.to contain_apt__source('cvmfs').with(
+                    {
+                      ensure: 'present',
+                      enabled: true,
+                      location: [
+                        'http://example.org/base',
+                        'http://example.net/base',
+                      ],
+                    }
+                  )
+                }
+
+              end
             end
           end
 


### PR DESCRIPTION
#### Pull Request (PR) description

On Debian 13 and what will be Ubuntu 26.04 configure a second APT repository which will be used in failover.

On Debian 11, 12 and Ubuntu 22.04, 24.04 only a single apt repository is supported.
